### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/184/473/421184473.geojson
+++ b/data/421/184/473/421184473.geojson
@@ -297,7 +297,8 @@
     "qs:woe_id":380894,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "wof:belongsto":[
         102191577,
@@ -316,6 +317,10 @@
     },
     "wof:country":"UY",
     "wof:created":1459009412,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"217dda9825861cd9886f25b6b2c5ff29",
     "wof:hierarchy":[
         {
@@ -326,7 +331,7 @@
         }
     ],
     "wof:id":421184473,
-    "wof:lastmodified":1566643130,
+    "wof:lastmodified":1582343192,
     "wof:name":"Artigas",
     "wof:parent_id":85680355,
     "wof:placetype":"locality",

--- a/data/421/185/967/421185967.geojson
+++ b/data/421/185/967/421185967.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"UY",
     "wof:created":1459009460,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73526dab9bec6b52a2eb63c19e64ecb4",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":421185967,
-    "wof:lastmodified":1566643135,
+    "wof:lastmodified":1582343192,
     "wof:name":"San Jos\u00e9 de Mayo",
     "wof:parent_id":85680349,
     "wof:placetype":"locality",

--- a/data/856/325/11/85632511.geojson
+++ b/data/856/325/11/85632511.geojson
@@ -1006,6 +1006,10 @@
     },
     "wof:country":"UY",
     "wof:country_alpha3":"URY",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"ccce184ef392a76b7708deb5eeca16e2",
     "wof:hierarchy":[
         {
@@ -1020,7 +1024,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566643033,
+    "wof:lastmodified":1582343189,
     "wof:name":"Uruguay",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/857/649/01/85764901.geojson
+++ b/data/857/649/01/85764901.geojson
@@ -90,6 +90,9 @@
         "qs_pg:id":1075809
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32329373489d007245e27f32677818ee",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643028,
+    "wof:lastmodified":1582343188,
     "wof:name":"Aguada",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/05/85764905.geojson
+++ b/data/857/649/05/85764905.geojson
@@ -108,6 +108,9 @@
         "qs_pg:id":1082758
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72239927131cdd6969c15a9be75ee9e2",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643028,
+    "wof:lastmodified":1582343188,
     "wof:name":"Arroyo Seco",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/09/85764909.geojson
+++ b/data/857/649/09/85764909.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Belvedere, Montevideo"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"26d123c74d411a6d610aa606a92fefea",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379804,
+    "wof:lastmodified":1582343188,
     "wof:name":"Belveder",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/13/85764913.geojson
+++ b/data/857/649/13/85764913.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Capurro"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c6797b582e6f186653eded5fc3d807c",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379804,
+    "wof:lastmodified":1582343188,
     "wof:name":"Capurro",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/19/85764919.geojson
+++ b/data/857/649/19/85764919.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Centro, Montevideo"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e976ea0120c815c3b81da0414bb5390e",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379804,
+    "wof:lastmodified":1582343188,
     "wof:name":"Centro",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/21/85764921.geojson
+++ b/data/857/649/21/85764921.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Cerrito, Montevideo"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bdcb645190558a79e10c9ebde6dc1d18",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643028,
+    "wof:lastmodified":1582343188,
     "wof:name":"Cerrito",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/25/85764925.geojson
+++ b/data/857/649/25/85764925.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q1005742"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d53fadd2132d8f940e58fc919aea98aa",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379804,
+    "wof:lastmodified":1582343188,
     "wof:name":"Cord\u00f3n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/29/85764929.geojson
+++ b/data/857/649/29/85764929.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Flor de Maro\u00f1as"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35f57f994cd913a14e56f65181f3f363",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643028,
+    "wof:lastmodified":1582343188,
     "wof:name":"Flor de Maro\u00f1as",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/35/85764935.geojson
+++ b/data/857/649/35/85764935.geojson
@@ -79,6 +79,9 @@
         "qs:id":1174659
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8072fa88a0dd127d4a48baed34957eb3",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379803,
+    "wof:lastmodified":1582343188,
     "wof:name":"La Floresta",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/39/85764939.geojson
+++ b/data/857/649/39/85764939.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Paso del Molino"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db4497d832c716d1d1442779312004de",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643029,
+    "wof:lastmodified":1582343188,
     "wof:name":"Paso Molino",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/43/85764943.geojson
+++ b/data/857/649/43/85764943.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Pocitos"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64afb3ec3c3ef455dd6d4a03c5ddc0ff",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643028,
+    "wof:lastmodified":1582343188,
     "wof:name":"Pocitos",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/47/85764947.geojson
+++ b/data/857/649/47/85764947.geojson
@@ -114,6 +114,9 @@
         "wk:page":"Punta Carretas"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"378e148c1979d248224a7b169929a2c9",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643029,
+    "wof:lastmodified":1582343188,
     "wof:name":"Punta Carretas",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/53/85764953.geojson
+++ b/data/857/649/53/85764953.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Uni\u00f3n, Montevideo"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"478ee8d31edd5efa04f7049820495bb9",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379804,
+    "wof:lastmodified":1582343188,
     "wof:name":"Uni\u00f3n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/55/85764955.geojson
+++ b/data/857/649/55/85764955.geojson
@@ -74,6 +74,9 @@
         "qs:id":1284798
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"76e4ac22afe8afe02b88209e7d10bcdb",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379804,
+    "wof:lastmodified":1582343188,
     "wof:name":"Villa Dolores",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/59/85764959.geojson
+++ b/data/857/649/59/85764959.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Villa Espa\u00f1ola"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2bc25c50c2614437ff5dd74baa77d2e2",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643028,
+    "wof:lastmodified":1582343188,
     "wof:name":"Villa Espa\u00f1ola",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/35/85765535.geojson
+++ b/data/857/655/35/85765535.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Reducto"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"99a490cb10412ddbf42fd25e093e6a5f",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643029,
+    "wof:lastmodified":1582343188,
     "wof:name":"Reducto",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/39/85765539.geojson
+++ b/data/857/655/39/85765539.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Villa Mu\u00f1oz"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ada3ac9ccf5d1e0092ed318d9d21af4",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643029,
+    "wof:lastmodified":1582343188,
     "wof:name":"Villa Mu\u00f1oz",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/43/85765543.geojson
+++ b/data/857/655/43/85765543.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Piri\u00e1polis"
     },
     "wof:country":"UY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5897e8a52b96e4a18c084a3488710036",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566643029,
+    "wof:lastmodified":1582343188,
     "wof:name":"Piri\u00e1polis",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/431/207/890431207.geojson
+++ b/data/890/431/207/890431207.geojson
@@ -303,6 +303,9 @@
     },
     "wof:country":"UY",
     "wof:created":1469051882,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e1303d2ec075e695c0c795a5357822a0",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         }
     ],
     "wof:id":890431207,
-    "wof:lastmodified":1566643137,
+    "wof:lastmodified":1582343192,
     "wof:name":"Florida",
     "wof:parent_id":85680325,
     "wof:placetype":"locality",

--- a/data/890/437/189/890437189.geojson
+++ b/data/890/437/189/890437189.geojson
@@ -261,6 +261,9 @@
     },
     "wof:country":"UY",
     "wof:created":1469052142,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad2bc93b19122dbda9a49f4c0a8d49c0",
     "wof:hierarchy":[
         {
@@ -271,7 +274,7 @@
         }
     ],
     "wof:id":890437189,
-    "wof:lastmodified":1566643137,
+    "wof:lastmodified":1582343192,
     "wof:name":"Paso de los Toros",
     "wof:parent_id":85680311,
     "wof:placetype":"locality",

--- a/data/890/437/681/890437681.geojson
+++ b/data/890/437/681/890437681.geojson
@@ -651,6 +651,10 @@
     ],
     "wof:country":"UY",
     "wof:created":1469052161,
+    "wof:geom_alt":[
+        "unknown",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"75f09cdca2716bc9fecd3c9ad91d3224",
     "wof:hierarchy":[
         {
@@ -662,7 +666,7 @@
         }
     ],
     "wof:id":890437681,
-    "wof:lastmodified":1578092640,
+    "wof:lastmodified":1582343192,
     "wof:megacity":1,
     "wof:name":"Montevideo",
     "wof:parent_id":1092076411,

--- a/data/890/438/277/890438277.geojson
+++ b/data/890/438/277/890438277.geojson
@@ -309,6 +309,9 @@
     },
     "wof:country":"UY",
     "wof:created":1469052187,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"67da2e26b71ccdda3cb211daae05a086",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         }
     ],
     "wof:id":890438277,
-    "wof:lastmodified":1566643137,
+    "wof:lastmodified":1582343192,
     "wof:name":"Tacuaremb\u00f3",
     "wof:parent_id":85680311,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.