### PR TITLE
uy concordances, placetype local, and more

### DIFF
--- a/data/109/207/454/1/1092074541.geojson
+++ b/data/109/207/454/1/1092074541.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092074541,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886178,
     "wof:name":"Santa Luc\u00eda",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/457/7/1092074577.geojson
+++ b/data/109/207/457/7/1092074577.geojson
@@ -112,7 +112,7 @@
         }
     ],
     "wof:id":1092074577,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886328,
     "wof:name":"Tala",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/461/5/1092074615.geojson
+++ b/data/109/207/461/5/1092074615.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1092074615,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886328,
     "wof:name":"San Ram\u00f3n",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/465/5/1092074655.geojson
+++ b/data/109/207/465/5/1092074655.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1092074655,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886324,
     "wof:name":"San Bautista",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/470/1/1092074701.geojson
+++ b/data/109/207/470/1/1092074701.geojson
@@ -385,7 +385,7 @@
         }
     ],
     "wof:id":1092074701,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886322,
     "wof:name":"San Antonio",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/473/5/1092074735.geojson
+++ b/data/109/207/473/5/1092074735.geojson
@@ -100,7 +100,7 @@
         }
     ],
     "wof:id":1092074735,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886327,
     "wof:name":"Nueva Palmira",
     "wof:parent_id":85680347,
     "wof:placetype":"county",

--- a/data/109/207/477/5/1092074775.geojson
+++ b/data/109/207/477/5/1092074775.geojson
@@ -130,7 +130,7 @@
         }
     ],
     "wof:id":1092074775,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886741,
     "wof:name":"San Javier",
     "wof:parent_id":85680367,
     "wof:placetype":"county",

--- a/data/109/207/482/1/1092074821.geojson
+++ b/data/109/207/482/1/1092074821.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092074821,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886178,
     "wof:name":"Sol\u00eds Grande",
     "wof:parent_id":85680335,
     "wof:placetype":"county",

--- a/data/109/207/485/7/1092074857.geojson
+++ b/data/109/207/485/7/1092074857.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092074857,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886513,
     "wof:name":"Municipio G",
     "wof:parent_id":85680339,
     "wof:placetype":"county",

--- a/data/109/207/490/5/1092074905.geojson
+++ b/data/109/207/490/5/1092074905.geojson
@@ -136,7 +136,7 @@
         }
     ],
     "wof:id":1092074905,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886742,
     "wof:name":"Lascano",
     "wof:parent_id":85680343,
     "wof:placetype":"county",

--- a/data/109/207/495/1/1092074951.geojson
+++ b/data/109/207/495/1/1092074951.geojson
@@ -112,7 +112,7 @@
         }
     ],
     "wof:id":1092074951,
-    "wof:lastmodified":1694498105,
+    "wof:lastmodified":1695886743,
     "wof:name":"Chuy",
     "wof:parent_id":85680343,
     "wof:placetype":"county",

--- a/data/109/207/498/3/1092074983.geojson
+++ b/data/109/207/498/3/1092074983.geojson
@@ -133,7 +133,7 @@
         }
     ],
     "wof:id":1092074983,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886742,
     "wof:name":"Castillos",
     "wof:parent_id":85680343,
     "wof:placetype":"county",

--- a/data/109/207/503/3/1092075033.geojson
+++ b/data/109/207/503/3/1092075033.geojson
@@ -85,7 +85,7 @@
         }
     ],
     "wof:id":1092075033,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886321,
     "wof:name":"Vichadero",
     "wof:parent_id":85680307,
     "wof:placetype":"county",

--- a/data/109/207/506/9/1092075069.geojson
+++ b/data/109/207/506/9/1092075069.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1092075069,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886501,
     "wof:name":"Minas de Corrales",
     "wof:parent_id":85680307,
     "wof:placetype":"county",

--- a/data/109/207/511/5/1092075115.geojson
+++ b/data/109/207/511/5/1092075115.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092075115,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886174,
     "wof:name":"Colonia Lavalleja",
     "wof:parent_id":85680289,
     "wof:placetype":"county",

--- a/data/109/207/516/1/1092075161.geojson
+++ b/data/109/207/516/1/1092075161.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":1092075161,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886324,
     "wof:name":"Mataojo",
     "wof:parent_id":85680289,
     "wof:placetype":"county",

--- a/data/109/207/519/3/1092075193.geojson
+++ b/data/109/207/519/3/1092075193.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092075193,
-    "wof:lastmodified":1694498183,
+    "wof:lastmodified":1695886527,
     "wof:name":"Bel\u00e9n",
     "wof:parent_id":85680289,
     "wof:placetype":"county",

--- a/data/109/207/523/9/1092075239.geojson
+++ b/data/109/207/523/9/1092075239.geojson
@@ -139,7 +139,7 @@
         }
     ],
     "wof:id":1092075239,
-    "wof:lastmodified":1694498105,
+    "wof:lastmodified":1695886743,
     "wof:name":"Baltasar Brum",
     "wof:parent_id":85680355,
     "wof:placetype":"county",

--- a/data/109/207/527/7/1092075277.geojson
+++ b/data/109/207/527/7/1092075277.geojson
@@ -109,7 +109,7 @@
         }
     ],
     "wof:id":1092075277,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886325,
     "wof:name":"Bella Uni\u00f3n",
     "wof:parent_id":85680355,
     "wof:placetype":"county",

--- a/data/109/207/530/3/1092075303.geojson
+++ b/data/109/207/530/3/1092075303.geojson
@@ -88,7 +88,7 @@
         }
     ],
     "wof:id":1092075303,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886325,
     "wof:name":"Tom\u00e1s Gomensoro",
     "wof:parent_id":85680355,
     "wof:placetype":"county",

--- a/data/109/207/535/1/1092075351.geojson
+++ b/data/109/207/535/1/1092075351.geojson
@@ -88,7 +88,7 @@
         }
     ],
     "wof:id":1092075351,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886321,
     "wof:name":"Villa Constituci\u00f3n",
     "wof:parent_id":85680289,
     "wof:placetype":"county",

--- a/data/109/207/538/7/1092075387.geojson
+++ b/data/109/207/538/7/1092075387.geojson
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":1092075387,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886178,
     "wof:name":"Rinc\u00f3n de Valent\u00edn",
     "wof:parent_id":85680289,
     "wof:placetype":"county",

--- a/data/109/207/539/3/1092075393.geojson
+++ b/data/109/207/539/3/1092075393.geojson
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":1092075393,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886742,
     "wof:name":"Paso de los Toros",
     "wof:parent_id":85680311,
     "wof:placetype":"county",

--- a/data/109/207/539/5/1092075395.geojson
+++ b/data/109/207/539/5/1092075395.geojson
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1092075395,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886742,
     "wof:name":"Carmelo",
     "wof:parent_id":85680347,
     "wof:placetype":"county",

--- a/data/109/207/539/7/1092075397.geojson
+++ b/data/109/207/539/7/1092075397.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092075397,
-    "wof:lastmodified":1694498184,
+    "wof:lastmodified":1695886534,
     "wof:name":"Juan L. Lacaze",
     "wof:parent_id":85680347,
     "wof:placetype":"county",

--- a/data/109/207/541/9/1092075419.geojson
+++ b/data/109/207/541/9/1092075419.geojson
@@ -103,7 +103,7 @@
         }
     ],
     "wof:id":1092075419,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886329,
     "wof:name":"Nueva Helvecia",
     "wof:parent_id":85680347,
     "wof:placetype":"county",

--- a/data/109/207/546/3/1092075463.geojson
+++ b/data/109/207/546/3/1092075463.geojson
@@ -160,7 +160,7 @@
         }
     ],
     "wof:id":1092075463,
-    "wof:lastmodified":1694498178,
+    "wof:lastmodified":1695886496,
     "wof:name":"San Carlos",
     "wof:parent_id":85680335,
     "wof:placetype":"county",

--- a/data/109/207/549/3/1092075493.geojson
+++ b/data/109/207/549/3/1092075493.geojson
@@ -91,7 +91,7 @@
         }
     ],
     "wof:id":1092075493,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886328,
     "wof:name":"Aigu\u00e1",
     "wof:parent_id":85680335,
     "wof:placetype":"county",

--- a/data/109/207/553/1/1092075531.geojson
+++ b/data/109/207/553/1/1092075531.geojson
@@ -127,7 +127,7 @@
         }
     ],
     "wof:id":1092075531,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886743,
     "wof:name":"Tranqueras",
     "wof:parent_id":85680307,
     "wof:placetype":"county",

--- a/data/109/207/556/5/1092075565.geojson
+++ b/data/109/207/556/5/1092075565.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1092075565,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886320,
     "wof:name":"Casup\u00e1",
     "wof:parent_id":85680325,
     "wof:placetype":"county",

--- a/data/109/207/558/7/1092075587.geojson
+++ b/data/109/207/558/7/1092075587.geojson
@@ -184,7 +184,7 @@
         }
     ],
     "wof:id":1092075587,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886741,
     "wof:name":"Punta del Este",
     "wof:parent_id":85680335,
     "wof:placetype":"county",

--- a/data/109/207/561/3/1092075613.geojson
+++ b/data/109/207/561/3/1092075613.geojson
@@ -103,7 +103,7 @@
         }
     ],
     "wof:id":1092075613,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886321,
     "wof:name":"Piri\u00e1polis",
     "wof:parent_id":85680335,
     "wof:placetype":"county",

--- a/data/109/207/563/9/1092075639.geojson
+++ b/data/109/207/563/9/1092075639.geojson
@@ -88,7 +88,7 @@
         }
     ],
     "wof:id":1092075639,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886326,
     "wof:name":"Migues",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/566/3/1092075663.geojson
+++ b/data/109/207/566/3/1092075663.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092075663,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886175,
     "wof:name":"Montes",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/568/1/1092075681.geojson
+++ b/data/109/207/568/1/1092075681.geojson
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":1092075681,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886178,
     "wof:name":"Soca",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/571/5/1092075715.geojson
+++ b/data/109/207/571/5/1092075715.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1092075715,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886526,
     "wof:name":"La Floresta",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/575/7/1092075757.geojson
+++ b/data/109/207/575/7/1092075757.geojson
@@ -100,7 +100,7 @@
         }
     ],
     "wof:id":1092075757,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886743,
     "wof:name":"Maldonado",
     "wof:parent_id":85680335,
     "wof:placetype":"county",

--- a/data/109/207/580/1/1092075801.geojson
+++ b/data/109/207/580/1/1092075801.geojson
@@ -115,7 +115,7 @@
         }
     ],
     "wof:id":1092075801,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886325,
     "wof:name":"Libertad",
     "wof:parent_id":85680349,
     "wof:placetype":"county",

--- a/data/109/207/583/7/1092075837.geojson
+++ b/data/109/207/583/7/1092075837.geojson
@@ -91,7 +91,7 @@
         }
     ],
     "wof:id":1092075837,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886329,
     "wof:name":"Aguas Corrientes",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/587/7/1092075877.geojson
+++ b/data/109/207/587/7/1092075877.geojson
@@ -103,7 +103,7 @@
         }
     ],
     "wof:id":1092075877,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886326,
     "wof:name":"Ciudad del Plata",
     "wof:parent_id":85680349,
     "wof:placetype":"county",

--- a/data/109/207/590/1/1092075901.geojson
+++ b/data/109/207/590/1/1092075901.geojson
@@ -94,7 +94,7 @@
         }
     ],
     "wof:id":1092075901,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886326,
     "wof:name":"Tarariras",
     "wof:parent_id":85680347,
     "wof:placetype":"county",

--- a/data/109/207/594/3/1092075943.geojson
+++ b/data/109/207/594/3/1092075943.geojson
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1092075943,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886741,
     "wof:name":"Rosario",
     "wof:parent_id":85680347,
     "wof:placetype":"county",

--- a/data/109/207/598/7/1092075987.geojson
+++ b/data/109/207/598/7/1092075987.geojson
@@ -94,7 +94,7 @@
         }
     ],
     "wof:id":1092075987,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886326,
     "wof:name":"Sarand\u00ed Grande",
     "wof:parent_id":85680325,
     "wof:placetype":"county",

--- a/data/109/207/601/7/1092076017.geojson
+++ b/data/109/207/601/7/1092076017.geojson
@@ -106,7 +106,7 @@
         }
     ],
     "wof:id":1092076017,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886327,
     "wof:name":"San Jacinto",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/605/9/1092076059.geojson
+++ b/data/109/207/605/9/1092076059.geojson
@@ -88,7 +88,7 @@
         }
     ],
     "wof:id":1092076059,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886322,
     "wof:name":"Empalme Olmos",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/610/3/1092076103.geojson
+++ b/data/109/207/610/3/1092076103.geojson
@@ -94,7 +94,7 @@
         }
     ],
     "wof:id":1092076103,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886322,
     "wof:name":"Atl\u00e1ntida",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/613/5/1092076135.geojson
+++ b/data/109/207/613/5/1092076135.geojson
@@ -85,7 +85,7 @@
         }
     ],
     "wof:id":1092076135,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886177,
     "wof:name":"Parque del Plata",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/615/7/1092076157.geojson
+++ b/data/109/207/615/7/1092076157.geojson
@@ -160,7 +160,7 @@
         }
     ],
     "wof:id":1092076157,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886743,
     "wof:name":"Santa Rosa",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/619/5/1092076195.geojson
+++ b/data/109/207/619/5/1092076195.geojson
@@ -166,7 +166,7 @@
         }
     ],
     "wof:id":1092076195,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886742,
     "wof:name":"Salinas",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/623/1/1092076231.geojson
+++ b/data/109/207/623/1/1092076231.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076231,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886177,
     "wof:name":"Paso Carrasco",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/625/1/1092076251.geojson
+++ b/data/109/207/625/1/1092076251.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076251,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886508,
     "wof:name":"Municipio CH",
     "wof:parent_id":85680339,
     "wof:placetype":"county",

--- a/data/109/207/627/7/1092076277.geojson
+++ b/data/109/207/627/7/1092076277.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076277,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886175,
     "wof:name":"Municipio B",
     "wof:parent_id":85680339,
     "wof:placetype":"county",

--- a/data/109/207/630/3/1092076303.geojson
+++ b/data/109/207/630/3/1092076303.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076303,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886176,
     "wof:name":"Municipio C",
     "wof:parent_id":85680339,
     "wof:placetype":"county",

--- a/data/109/207/632/1/1092076321.geojson
+++ b/data/109/207/632/1/1092076321.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076321,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886176,
     "wof:name":"Municipio A",
     "wof:parent_id":85680339,
     "wof:placetype":"county",

--- a/data/109/207/633/9/1092076339.geojson
+++ b/data/109/207/633/9/1092076339.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1092076339,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886175,
     "wof:name":"Ciudad de la Costa",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/635/9/1092076359.geojson
+++ b/data/109/207/635/9/1092076359.geojson
@@ -85,7 +85,7 @@
         }
     ],
     "wof:id":1092076359,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886175,
     "wof:name":"Colonia Nicolich",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/638/3/1092076383.geojson
+++ b/data/109/207/638/3/1092076383.geojson
@@ -106,7 +106,7 @@
         }
     ],
     "wof:id":1092076383,
-    "wof:lastmodified":1694497842,
+    "wof:lastmodified":1695886329,
     "wof:name":"Barros Blancos",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/641/1/1092076411.geojson
+++ b/data/109/207/641/1/1092076411.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076411,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886505,
     "wof:name":"Municipio D",
     "wof:parent_id":85680339,
     "wof:placetype":"county",

--- a/data/109/207/642/9/1092076429.geojson
+++ b/data/109/207/642/9/1092076429.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076429,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886509,
     "wof:name":"Municipio F",
     "wof:parent_id":85680339,
     "wof:placetype":"county",

--- a/data/109/207/644/5/1092076445.geojson
+++ b/data/109/207/644/5/1092076445.geojson
@@ -196,7 +196,7 @@
         }
     ],
     "wof:id":1092076445,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886741,
     "wof:name":"Toledo",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/646/9/1092076469.geojson
+++ b/data/109/207/646/9/1092076469.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076469,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886178,
     "wof:name":"Su\u00e1rez",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/648/1/1092076481.geojson
+++ b/data/109/207/648/1/1092076481.geojson
@@ -109,7 +109,7 @@
         }
     ],
     "wof:id":1092076481,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886516,
     "wof:name":"Pando",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/650/5/1092076505.geojson
+++ b/data/109/207/650/5/1092076505.geojson
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":1092076505,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886174,
     "wof:name":"Los Cerrillos",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/652/9/1092076529.geojson
+++ b/data/109/207/652/9/1092076529.geojson
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1092076529,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886743,
     "wof:name":"Canelones",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/654/5/1092076545.geojson
+++ b/data/109/207/654/5/1092076545.geojson
@@ -103,7 +103,7 @@
         }
     ],
     "wof:id":1092076545,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886175,
     "wof:name":"Las Piedras",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/657/1/1092076571.geojson
+++ b/data/109/207/657/1/1092076571.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076571,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886174,
     "wof:name":"18 de Mayo",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/659/5/1092076595.geojson
+++ b/data/109/207/659/5/1092076595.geojson
@@ -106,7 +106,7 @@
         }
     ],
     "wof:id":1092076595,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886742,
     "wof:name":"Progreso",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/661/5/1092076615.geojson
+++ b/data/109/207/661/5/1092076615.geojson
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1092076615,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886324,
     "wof:name":"Chapicuy",
     "wof:parent_id":85680363,
     "wof:placetype":"county",

--- a/data/109/207/663/7/1092076637.geojson
+++ b/data/109/207/663/7/1092076637.geojson
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1092076637,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886518,
     "wof:name":"Quebracho",
     "wof:parent_id":85680363,
     "wof:placetype":"county",

--- a/data/109/207/667/9/1092076679.geojson
+++ b/data/109/207/667/9/1092076679.geojson
@@ -76,7 +76,7 @@
         }
     ],
     "wof:id":1092076679,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886323,
     "wof:name":"Lorenzo Geyres",
     "wof:parent_id":85680363,
     "wof:placetype":"county",

--- a/data/109/207/670/3/1092076703.geojson
+++ b/data/109/207/670/3/1092076703.geojson
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1092076703,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886327,
     "wof:name":"Tambores",
     "wof:parent_id":85680363,
     "wof:placetype":"county",

--- a/data/109/207/672/5/1092076725.geojson
+++ b/data/109/207/672/5/1092076725.geojson
@@ -91,7 +91,7 @@
         }
     ],
     "wof:id":1092076725,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886322,
     "wof:name":"Guich\u00f3n",
     "wof:parent_id":85680363,
     "wof:placetype":"county",

--- a/data/109/207/674/7/1092076747.geojson
+++ b/data/109/207/674/7/1092076747.geojson
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1092076747,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886323,
     "wof:name":"Piedras Coloradas",
     "wof:parent_id":85680363,
     "wof:placetype":"county",

--- a/data/109/207/676/9/1092076769.geojson
+++ b/data/109/207/676/9/1092076769.geojson
@@ -85,7 +85,7 @@
         }
     ],
     "wof:id":1092076769,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886502,
     "wof:name":"Porvenir",
     "wof:parent_id":85680363,
     "wof:placetype":"county",

--- a/data/109/207/678/7/1092076787.geojson
+++ b/data/109/207/678/7/1092076787.geojson
@@ -151,7 +151,7 @@
         }
     ],
     "wof:id":1092076787,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886743,
     "wof:name":"Young",
     "wof:parent_id":85680367,
     "wof:placetype":"county",

--- a/data/109/207/682/5/1092076825.geojson
+++ b/data/109/207/682/5/1092076825.geojson
@@ -85,7 +85,7 @@
         }
     ],
     "wof:id":1092076825,
-    "wof:lastmodified":1694497841,
+    "wof:lastmodified":1695886326,
     "wof:name":"Nuevo Berl\u00edn",
     "wof:parent_id":85680367,
     "wof:placetype":"county",

--- a/data/109/207/686/3/1092076863.geojson
+++ b/data/109/207/686/3/1092076863.geojson
@@ -115,7 +115,7 @@
         }
     ],
     "wof:id":1092076863,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886741,
     "wof:name":"La Paloma",
     "wof:parent_id":85680343,
     "wof:placetype":"county",

--- a/data/109/207/689/1/1092076891.geojson
+++ b/data/109/207/689/1/1092076891.geojson
@@ -406,7 +406,7 @@
         }
     ],
     "wof:id":1092076891,
-    "wof:lastmodified":1694498104,
+    "wof:lastmodified":1695886742,
     "wof:name":"La Paz",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/693/3/1092076933.geojson
+++ b/data/109/207/693/3/1092076933.geojson
@@ -244,7 +244,7 @@
         }
     ],
     "wof:id":1092076933,
-    "wof:lastmodified":1694497840,
+    "wof:lastmodified":1695886323,
     "wof:name":"Sauce",
     "wof:parent_id":85680321,
     "wof:placetype":"county",

--- a/data/109/207/697/1/1092076971.geojson
+++ b/data/109/207/697/1/1092076971.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092076971,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886177,
     "wof:name":"Pan de Az\u00facar",
     "wof:parent_id":85680335,
     "wof:placetype":"county",

--- a/data/109/207/698/7/1092076987.geojson
+++ b/data/109/207/698/7/1092076987.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1092076987,
-    "wof:lastmodified":1694498068,
+    "wof:lastmodified":1695886175,
     "wof:name":"Garz\u00f3n",
     "wof:parent_id":85680335,
     "wof:placetype":"county",

--- a/data/109/207/702/5/1092077025.geojson
+++ b/data/109/207/702/5/1092077025.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092077025,
-    "wof:lastmodified":1694498179,
+    "wof:lastmodified":1695886500,
     "wof:name":"Municipio E",
     "wof:parent_id":85680339,
     "wof:placetype":"county",

--- a/data/109/207/706/5/1092077065.geojson
+++ b/data/109/207/706/5/1092077065.geojson
@@ -385,7 +385,7 @@
         }
     ],
     "wof:id":1092077065,
-    "wof:lastmodified":1694497839,
+    "wof:lastmodified":1695886321,
     "wof:name":"San Antonio",
     "wof:parent_id":85680289,
     "wof:placetype":"county",

--- a/data/109/207/709/5/1092077095.geojson
+++ b/data/109/207/709/5/1092077095.geojson
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":1092077095,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886179,
     "wof:name":"R\u00edo Branco",
     "wof:parent_id":85680299,
     "wof:placetype":"county",

--- a/data/856/325/11/85632511.geojson
+++ b/data/856/325/11/85632511.geojson
@@ -1204,6 +1204,7 @@
         "hasc:id":"UY",
         "icao:code":"CX",
         "ioc:id":"URU",
+        "iso:code":"UY",
         "itu:id":"URG",
         "loc:id":"n50000647",
         "m49:code":"858",
@@ -1218,6 +1219,7 @@
         "wk:page":"Uruguay",
         "wmo:id":"UY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
     "wof:country_alpha3":"URY",
     "wof:geom_alt":[
@@ -1238,7 +1240,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639523,
+    "wof:lastmodified":1695881179,
     "wof:name":"Uruguay",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/802/89/85680289.geojson
+++ b/data/856/802/89/85680289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.356067,
-    "geom:area_square_m":14322468087.518755,
+    "geom:area_square_m":14322467181.248188,
     "geom:bbox":"-58.075236,-31.871336,-56.009874,-30.752231",
     "geom:latitude":-31.332916,
     "geom:longitude":-57.027904,
@@ -311,14 +311,16 @@
         "gn:id":3440711,
         "gp:id":2347654,
         "hasc:id":"UY.SA",
+        "iso:code":"UY-SA",
         "iso:id":"UY-SA",
         "qs_pg:id":235654,
         "unlc:id":"UY-SA",
         "wd:id":"Q16595",
         "wk:page":"Salto Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"046dbaecd5075cc84ce738bbe0882f47",
+    "wof:geomhash":"84f8c547bdf6ffd7056907c04b3c25a8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893294,
+    "wof:lastmodified":1695884327,
     "wof:name":"Salto",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/802/93/85680293.geojson
+++ b/data/856/802/93/85680293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.876216,
-    "geom:area_square_m":9032834448.133883,
+    "geom:area_square_m":9032836987.966518,
     "geom:bbox":"-58.439361,-33.962991,-57.077725,-33.021395",
     "geom:latitude":-33.517932,
     "geom:longitude":-57.747346,
@@ -311,14 +311,16 @@
         "gn:id":3440054,
         "gp:id":2347656,
         "hasc:id":"UY.SO",
+        "iso:code":"UY-SO",
         "iso:id":"UY-SO",
         "qs_pg:id":1285582,
         "unlc:id":"UY-SO",
         "wd:id":"Q16584",
         "wk:page":"Soriano Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"35997e8b57527615b6cf68f91008986c",
+    "wof:geomhash":"e9240eacaad1fafe336dc92e7806b3b5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893294,
+    "wof:lastmodified":1695884857,
     "wof:name":"Soriano",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/802/99/85680299.geojson
+++ b/data/856/802/99/85680299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.324336,
-    "geom:area_square_m":13819939894.842175,
+    "geom:area_square_m":13819940110.858807,
     "geom:bbox":"-55.344808,-33.024961,-53.110836,-31.664237",
     "geom:latitude":-32.441466,
     "geom:longitude":-54.336476,
@@ -320,14 +320,16 @@
         "gn:id":3443173,
         "gp:id":2347642,
         "hasc:id":"UY.CL",
+        "iso:code":"UY-CL",
         "iso:id":"UY-CL",
         "qs_pg:id":427344,
         "unlc:id":"UY-CL",
         "wd:id":"Q16575",
         "wk:page":"Cerro Largo Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"66a6646a5e8c2a34db630de0a388f370",
+    "wof:geomhash":"22c9e67496c0ec957a3d383fcf2e0f08",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -342,7 +344,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893294,
+    "wof:lastmodified":1695884857,
     "wof:name":"Cerro Largo",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/03/85680303.geojson
+++ b/data/856/803/03/85680303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.158666,
-    "geom:area_square_m":12011362548.254562,
+    "geom:area_square_m":12011363044.713459,
     "geom:bbox":"-57.179037,-33.497077,-55.00997,-32.427323",
     "geom:latitude":-33.031356,
     "geom:longitude":-56.016523,
@@ -311,14 +311,16 @@
         "gn:id":3442720,
         "gp:id":2347644,
         "hasc:id":"UY.DU",
+        "iso:code":"UY-DU",
         "iso:id":"UY-DU",
         "qs_pg:id":319195,
         "unlc:id":"UY-DU",
         "wd:id":"Q16591",
         "wk:page":"Durazno Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"69961d22966830f7e04508b77971fb18",
+    "wof:geomhash":"bd8339e3173d67df9b324108ee7be5f8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893290,
+    "wof:lastmodified":1695884857,
     "wof:name":"Durazno",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/07/85680307.geojson
+++ b/data/856/803/07/85680307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.889494,
-    "geom:area_square_m":9379551291.903786,
+    "geom:area_square_m":9379552897.489681,
     "geom:bbox":"-56.188219,-32.122845,-54.467221,-30.843388",
     "geom:latitude":-31.483485,
     "geom:longitude":-55.260218,
@@ -308,14 +308,16 @@
         "gn:id":3440780,
         "gp:id":2347652,
         "hasc:id":"UY.RV",
+        "iso:code":"UY-RV",
         "iso:id":"UY-RV",
         "qs_pg:id":1285581,
         "unlc:id":"UY-RV",
         "wd:id":"Q16609",
         "wk:page":"Rivera Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"c65a774559e2e9f3f5219f42865a6dc4",
+    "wof:geomhash":"77ab27abf5cce30f71d7da5513065b00",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893292,
+    "wof:lastmodified":1695884326,
     "wof:name":"Rivera",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/11/85680311.geojson
+++ b/data/856/803/11/85680311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.523868,
-    "geom:area_square_m":15957995967.486538,
+    "geom:area_square_m":15957997993.947502,
     "geom:bbox":"-56.666794,-32.861095,-54.654514,-31.256076",
     "geom:latitude":-32.122801,
     "geom:longitude":-55.777651,
@@ -321,14 +321,16 @@
         "gn:id":3440033,
         "gp:id":2347657,
         "hasc:id":"UY.TA",
+        "iso:code":"UY-TA",
         "iso:id":"UY-TA",
         "qs_pg:id":1285583,
         "unlc:id":"UY-TA",
         "wd:id":"Q16587",
         "wk:page":"Tacuaremb\u00f3 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"a75b39cdbea23303464c88d113221dbc",
+    "wof:geomhash":"5d59bef801ab92234675db3b6cd6fa01",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893291,
+    "wof:lastmodified":1695884326,
     "wof:name":"Tacuaremb\u00f3",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/17/85680317.geojson
+++ b/data/856/803/17/85680317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.926003,
-    "geom:area_square_m":9596258500.470236,
+    "geom:area_square_m":9596258257.315407,
     "geom:bbox":"-55.148385,-33.465347,-53.182836,-32.705084",
     "geom:latitude":-33.060936,
     "geom:longitude":-54.250471,
@@ -312,14 +312,16 @@
         "gn:id":3439780,
         "gp:id":2347658,
         "hasc:id":"UY.TT",
+        "iso:code":"UY-TT",
         "iso:id":"UY-TT",
         "qs_pg:id":895012,
         "unlc:id":"UY-TT",
         "wd:id":"Q16610",
         "wk:page":"Treinta y Tres Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"a3ca01664930754016468f3262a6de96",
+    "wof:geomhash":"21992f8cb23c39e93af3e4dfd4891afd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893291,
+    "wof:lastmodified":1695884857,
     "wof:name":"Treinta y Tres",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/21/85680321.geojson
+++ b/data/856/803/21/85680321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.448884,
-    "geom:area_square_m":4571925237.939023,
+    "geom:area_square_m":4571925818.490479,
     "geom:bbox":"-56.471922,-34.885804,-55.373764,-34.207731",
     "geom:latitude":-34.543853,
     "geom:longitude":-55.920984,
@@ -317,14 +317,16 @@
         "gn:id":3443411,
         "gp:id":2347641,
         "hasc:id":"UY.CA",
+        "iso:code":"UY-CA",
         "iso:id":"UY-CA",
         "qs_pg:id":1114957,
         "unlc:id":"UY-CA",
         "wd:id":"Q16577",
         "wk:page":"Canelones Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"1dd9f9ed312d6fec09341e42ab28311a",
+    "wof:geomhash":"932fabd9ca6cd5ede62a2e38d3f361a4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893292,
+    "wof:lastmodified":1695884857,
     "wof:name":"Canelones",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/25/85680325.geojson
+++ b/data/856/803/25/85680325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.014791,
-    "geom:area_square_m":10429624139.656784,
+    "geom:area_square_m":10429622704.235718,
     "geom:bbox":"-56.532978,-34.432988,-55.091076,-33.118237",
     "geom:latitude":-33.779524,
     "geom:longitude":-55.857539,
@@ -312,14 +312,16 @@
         "gn:id":3442584,
         "gp:id":2347646,
         "hasc:id":"UY.FD",
+        "iso:code":"UY-FD",
         "iso:id":"UY-FD",
         "qs_pg:id":424135,
         "unlc:id":"UY-FD",
         "wd:id":"Q16593",
         "wk:page":"Florida Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"4af0b338077cc79507c7266f06daebc6",
+    "wof:geomhash":"83a2ee381befed51805f50c342335ead",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893294,
+    "wof:lastmodified":1695884857,
     "wof:name":"Florida",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/29/85680329.geojson
+++ b/data/856/803/29/85680329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.98896,
-    "geom:area_square_m":10146851130.7444,
+    "geom:area_square_m":10146850617.258808,
     "geom:bbox":"-55.619106,-34.621917,-54.125709,-33.336983",
     "geom:latitude":-33.92458,
     "geom:longitude":-54.971614,
@@ -313,14 +313,16 @@
         "gn:id":3442007,
         "gp:id":2347647,
         "hasc:id":"UY.LA",
+        "iso:code":"UY-LA",
         "iso:id":"UY-LA",
         "qs_pg:id":235652,
         "unlc:id":"UY-LA",
         "wd:id":"Q460435",
         "wk:page":"Lavalleja Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"2b79dc4492b91cffb199702c52bb3d81",
+    "wof:geomhash":"42627db245cbe6b33d9bd90bd71f6b67",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893291,
+    "wof:lastmodified":1695884857,
     "wof:name":"Lavalleja",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/35/85680335.geojson
+++ b/data/856/803/35/85680335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.47287,
-    "geom:area_square_m":4814880262.019632,
+    "geom:area_square_m":4814882267.329317,
     "geom:bbox":"-55.473275,-34.973403,-54.460882,-33.926043",
     "geom:latitude":-34.566689,
     "geom:longitude":-54.852985,
@@ -314,14 +314,16 @@
         "gn:id":3441890,
         "gp:id":2347648,
         "hasc:id":"UY.MA",
+        "iso:code":"UY-MA",
         "iso:id":"UY-MA",
         "qs_pg:id":424136,
         "unlc:id":"UY-MA",
         "wd:id":"Q331196",
         "wk:page":"Maldonado Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"37cf3315a76a5892c3d172e308d3ed72",
+    "wof:geomhash":"1824cb5acc963ba2ed13a7cb7d06afd3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893290,
+    "wof:lastmodified":1695884857,
     "wof:name":"Maldonado",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/39/85680339.geojson
+++ b/data/856/803/39/85680339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053184,
-    "geom:area_square_m":539863129.565016,
+    "geom:area_square_m":539863567.285262,
     "geom:bbox":"-56.420766,-34.941188,-56.035876,-34.713436",
     "geom:latitude":-34.82215,
     "geom:longitude":-56.218756,
@@ -318,17 +318,19 @@
         "gn:id":3441572,
         "gp:id":2347649,
         "hasc:id":"UY.MO",
+        "iso:code":"UY-MO",
         "iso:id":"UY-MO",
         "qs_pg:id":222853,
         "unlc:id":"UY-MO",
         "wd:id":"Q16594",
         "wk:page":"Montevideo Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         890437681
     ],
     "wof:country":"UY",
-    "wof:geomhash":"627a312f6829e231832629393a493a0b",
+    "wof:geomhash":"8b10297f0602dee8d4233fb2b379e379",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893292,
+    "wof:lastmodified":1695884327,
     "wof:name":"Montevideo",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/43/85680343.geojson
+++ b/data/856/803/43/85680343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.056292,
-    "geom:area_square_m":10834227172.1108,
+    "geom:area_square_m":10834225992.421623,
     "geom:bbox":"-54.538164,-34.806899,-53.379095,-33.124979",
     "geom:latitude":-33.950937,
     "geom:longitude":-54.003912,
@@ -305,14 +305,16 @@
         "gn:id":3440771,
         "gp:id":2347653,
         "hasc:id":"UY.RO",
+        "iso:code":"UY-RO",
         "iso:id":"UY-RO",
         "qs_pg:id":319250,
         "unlc:id":"UY-RO",
         "wd:id":"Q16582",
         "wk:page":"Rocha Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"78f749634e5eae650a3a0a214486ae7c",
+    "wof:geomhash":"54e3e585b930c00523bdfb03312b9e0f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893292,
+    "wof:lastmodified":1695884857,
     "wof:name":"Rocha",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/47/85680347.geojson
+++ b/data/856/803/47/85680347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.605119,
-    "geom:area_square_m":6193401162.192667,
+    "geom:area_square_m":6193401196.885736,
     "geom:bbox":"-58.415617,-34.475109,-56.94179,-33.77799",
     "geom:latitude":-34.13356,
     "geom:longitude":-57.649022,
@@ -332,14 +332,16 @@
         "gn:id":3443025,
         "gp:id":2347643,
         "hasc:id":"UY.CO",
+        "iso:code":"UY-CO",
         "iso:id":"UY-CO",
         "qs_pg:id":221189,
         "unlc:id":"UY-CO",
         "wd:id":"Q16580",
         "wk:page":"Colonia Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"32373911adf20e539559b1a85631e7a5",
+    "wof:geomhash":"3a583c956d8b597198d6240d1ef1b2f0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -354,7 +356,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893293,
+    "wof:lastmodified":1695884327,
     "wof:name":"Colonia",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/49/85680349.geojson
+++ b/data/856/803/49/85680349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.481331,
-    "geom:area_square_m":4915662086.318113,
+    "geom:area_square_m":4915663988.170509,
     "geom:bbox":"-57.167478,-34.793535,-56.354229,-33.849716",
     "geom:latitude":-34.317727,
     "geom:longitude":-56.718176,
@@ -339,14 +339,16 @@
         "gn:id":3440645,
         "gp:id":2347655,
         "hasc:id":"UY.SJ",
+        "iso:code":"UY-SJ",
         "iso:id":"UY-SJ",
         "qs_pg:id":235655,
         "unlc:id":"UY-SJ",
         "wd:id":"Q16579",
         "wk:page":"San Jos\u00e9 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"36755fd8adf78702e2c5376c541b68a9",
+    "wof:geomhash":"8b340b4ff9506d13d5332e3dd77d3c3d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893293,
+    "wof:lastmodified":1695884327,
     "wof:name":"San Jos\u00e9",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/55/85680355.geojson
+++ b/data/856/803/55/85680355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.146372,
-    "geom:area_square_m":12198265859.072678,
+    "geom:area_square_m":12198264999.924007,
     "geom:bbox":"-57.889769,-31.078723,-55.988955,-30.09687",
     "geom:latitude":-30.62219,
     "geom:longitude":-56.968816,
@@ -327,14 +327,16 @@
         "gn:id":3443756,
         "gp:id":2347640,
         "hasc:id":"UY.AR",
+        "iso:code":"UY-AR",
         "iso:id":"UY-AR",
         "qs_pg:id":9281,
         "unlc:id":"UY-AR",
         "wd:id":"Q16603",
         "wk:page":"Artigas Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"f6644355ed46848effd561b3f1b98f9a",
+    "wof:geomhash":"1c2d048f8280e2960f8df463a494c039",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -349,7 +351,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893293,
+    "wof:lastmodified":1695884857,
     "wof:name":"Artigas",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/59/85680359.geojson
+++ b/data/856/803/59/85680359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.497981,
-    "geom:area_square_m":5130194665.261138,
+    "geom:area_square_m":5130193394.812341,
     "geom:bbox":"-57.347993,-33.988364,-56.42177,-33.123094",
     "geom:latitude":-33.576976,
     "geom:longitude":-56.887499,
@@ -311,14 +311,16 @@
         "gn:id":3442587,
         "gp:id":2347645,
         "hasc:id":"UY.FS",
+        "iso:code":"UY-FS",
         "iso:id":"UY-FS",
         "qs_pg:id":479628,
         "unlc:id":"UY-FS",
         "wd:id":"Q16578",
         "wk:page":"Flores Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"5b7131f906695d3042fc58646d1cde74",
+    "wof:geomhash":"717ec0b25ffd0b5f68c3c72e128eb9e6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893290,
+    "wof:lastmodified":1695884857,
     "wof:name":"Flores",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/63/85680363.geojson
+++ b/data/856/803/63/85680363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.342656,
-    "geom:area_square_m":14066555519.89341,
+    "geom:area_square_m":14066553462.838837,
     "geom:bbox":"-58.202618,-32.614288,-56.244856,-31.47043",
     "geom:latitude":-32.083262,
     "geom:longitude":-57.345083,
@@ -316,14 +316,16 @@
         "gn:id":3441242,
         "gp:id":2347650,
         "hasc:id":"UY.PA",
+        "iso:code":"UY-PA",
         "iso:id":"UY-PA",
         "qs_pg:id":235653,
         "unlc:id":"UY-PA",
         "wd:id":"Q16576",
         "wk:page":"Paysand\u00fa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"a6ed3581545b2fcfc83a154cc32ee3bf",
+    "wof:geomhash":"abf62cd9dea15ee1250a0a1b8e64fce1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893293,
+    "wof:lastmodified":1695884327,
     "wof:name":"Paysand\u00fa",
     "wof:parent_id":85632511,
     "wof:placetype":"region",

--- a/data/856/803/67/85680367.geojson
+++ b/data/856/803/67/85680367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.913144,
-    "geom:area_square_m":9492705374.880537,
+    "geom:area_square_m":9492705659.135841,
     "geom:bbox":"-58.418935,-33.424446,-56.559359,-32.363399",
     "geom:latitude":-32.78338,
     "geom:longitude":-57.426951,
@@ -313,14 +313,16 @@
         "gn:id":3440789,
         "gp:id":2347651,
         "hasc:id":"UY.RN",
+        "iso:code":"UY-RN",
         "iso:id":"UY-RN",
         "qs_pg:id":424137,
         "unlc:id":"UY-RN",
         "wd:id":"Q16596",
         "wk:page":"R\u00edo Negro Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UY",
-    "wof:geomhash":"31c344e429249427c63ee70dbf5aa2dd",
+    "wof:geomhash":"8f15ea085426035b9a76fc42fd44fe84",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690893291,
+    "wof:lastmodified":1695884326,
     "wof:name":"R\u00edo Negro",
     "wof:parent_id":85632511,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.